### PR TITLE
Add Zephyr support

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -155,7 +155,7 @@ module.exports = grammar({
     ),
 
     type_definition_default: $ => seq(
-      choice('def_bool', 'def_tristate'),
+      choice('def_bool', 'def_tristate', 'def_int', 'def_hex', 'def_string'),
       $.expression,
       optional($.conditional_clause),
       /\n/,

--- a/grammar.js
+++ b/grammar.js
@@ -48,6 +48,7 @@ module.exports = grammar({
 
     _entry: $ => choice(
       $.config,
+      $.configdefault,
       $.menuconfig,
       $.choice,
       $.comment_entry,
@@ -61,6 +62,13 @@ module.exports = grammar({
       'config',
       field('name', $.symbol),
       repeat1($._config_option),
+    ),
+
+    // zephyr extension
+    configdefault: $ => seq(
+      'configdefault',
+      field('name', $.symbol),
+      repeat1($.default_value),
     ),
 
     menuconfig: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -239,8 +239,8 @@ module.exports = grammar({
     macro_content: _ => /([^\$'"\)]|(\([^\)]*\))|(\\\$)|\$[^(])+/,
 
     prompt: _ => token(choice(
-      seq('"', repeat(choice(/[^"\\]/, /\\./)), '"'),
-      seq('\'', repeat(choice(/[^'\\]/, /\\./)), '\''),
+      seq('"', repeat(choice(/[^"\\]/, /\\(.|\n)/)), '"'),
+      seq('\'', repeat(choice(/[^'\\]/, /\\(.|\n)/)), '\''),
     )),
 
     symbol: _ => /-?[a-zA-Z0-9_]+/,

--- a/grammar.js
+++ b/grammar.js
@@ -243,7 +243,7 @@ module.exports = grammar({
       seq('\'', repeat(choice(/[^'\\]/, /\\(.|\n)/)), '\''),
     )),
 
-    symbol: _ => /-?[a-zA-Z0-9_]+/,
+    symbol: _ => /-?[a-zA-Z0-9_-]+/,
 
     comment: _ => token(seq('#', /.*/)),
   },

--- a/grammar.js
+++ b/grammar.js
@@ -106,7 +106,10 @@ module.exports = grammar({
       'endif',
     ),
 
-    source: $ => seq('source', $.prompt),
+    source: $ => seq(
+      choice('source', 'rsource', 'osource', 'orsource'),
+      $.prompt,
+    ),
 
     variable: $ => seq(
       field('left', $.symbol),

--- a/script/parse-examples
+++ b/script/parse-examples
@@ -16,6 +16,7 @@ function clone_repo {
 }
 
 clone_repo torvalds linux
+clone_repo zephyrproject-rtos zephyr
 
 known_failures="$(cat script/known_failures.txt)"
 


### PR DESCRIPTION
The [zephyr project ](https://github.com/zephyrproject-rtos/zephyr) uses `kconfig` similar to linux with [extensions](https://docs.zephyrproject.org/latest/build/kconfig/extensions.html). (Both are part of the linux foundation)

This PR aims to support the zephyr extensions and increase testing coverage.

As the test shows, not everything is covered yet, but I wanted to create the PR already for some feedback.

Fixes #8